### PR TITLE
ikke kjør playwright-rapport på dependabot branch

### DIFF
--- a/.github/workflows/next-js.yml
+++ b/.github/workflows/next-js.yml
@@ -322,7 +322,7 @@ jobs:
           retention-days: 1
 
   playwright-rapport:
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && !startsWith(github.ref_name, 'dependabot/') }}
     needs: [playwright]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
playwright-rapport krever tilgang for `dependabot` til `secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER` for å autentisere mot gcloud.

Foreslår å skippe rapporten for dependabot PRs.
Jeg kjenner ikke fullstendig hvordan vi bruker rapporten, så kan være bedre løsninger her.

Ref: https://nav-it.slack.com/archives/G0112C98QG3/p1734700124533949