### PR TITLE
Optimalisert Playwright-cache

### DIFF
--- a/.github/workflows/next-js-playwright-cache.yml
+++ b/.github/workflows/next-js-playwright-cache.yml
@@ -285,23 +285,27 @@ jobs:
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
     steps:
-      - name: cache workspace
+      - name: Cache workspace
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}
-          key: ${{ github.sha }}
+          key: workspace-${{ hashFiles('**/package-lock.json') }}
       - name: Cache Playwright browsers
         uses: actions/cache@v5
+        id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ needs.playwright-install-browsers.outputs.playwright-version }}
           restore-keys: |
             ${{ runner.os }}-playwright-
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install
       - name: Run Playwright
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-      - name: Upload blob report to GitHub Actions Artifacts
+      - name: Upload Playwright report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Skiller mellom installasjon av nettlesere og systemavhengigheter for å redusere unødvendig nettverkstrafikk.
Ved å splitte opp installasjonssteget kan agrede nettleser-binærfiler gjenbrukes. Systembiblioteker
installeres separat. Cache-treff brukes for nettlesere; men siden GitHub Actions-kjørerne er ny virtuelle
maskiner, må systembiblioteker installeres ved hver kjøring.
