### PR TITLE
Bygg next separat per miljø

### DIFF
--- a/.github/workflows/next-js16-docker.yml
+++ b/.github/workflows/next-js16-docker.yml
@@ -1,0 +1,435 @@
+name: Next.js 16
+on:
+  workflow_call:
+    inputs:
+      app:
+        required: false
+        default: ${{ github.event.repository.name }}
+        type: string
+      base-path:
+        required: true
+        type: string
+    outputs:
+      image-dev:
+        value: ${{ jobs.bygg-dev.outputs.image }}
+      image-prod:
+        value: ${{ jobs.bygg-prod.outputs.image }}
+      image-demo:
+        value: ${{ jobs.bygg-demo.outputs.image-gar }}
+
+# Bygger per miljø fordi Next.js 16 baker inn miljøvariabler (NEXT_PUBLIC_*) ved byggetidspunktet.
+# Forventer miljøfiler i nais/envs/.env.dev, .env.prod og .env.demo.
+
+jobs:
+  installer:
+    permissions:
+      packages: read
+      contents: read
+    name: Installer avhengigheter
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      playwright-version: ${{ steps.playwright-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+      - name: Installer npm-avhengigheter
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm ci
+      - name: Hent Playwright-versjon
+        id: playwright-version
+        run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")" >> $GITHUB_OUTPUT
+      - name: Cache workspace
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}
+          key: workspace-${{ github.sha }}
+
+  bygg-dev:
+    permissions:
+      packages: read
+      contents: read
+      id-token: write
+    name: Bygg og publiser dev
+    timeout-minutes: 15
+    needs: installer
+    if: github.ref_name == 'main' || startsWith(github.ref_name, 'dev-')
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+    steps:
+      - name: Gjenopprett workspace
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}
+          key: workspace-${{ github.sha }}
+      - name: Next.js cache (dev)
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-dev-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-dev-${{ hashFiles('**/package-lock.json') }}-
+      - name: Kopier dev-miljøfil
+        run: cp nais/envs/.env.dev .env.production
+      - name: Bygg applikasjon
+        run: npm run build
+        env:
+          NEXT_PUBLIC_VERSION: ${{ github.sha }}
+      - name: Last opp statiske filer til NAV CDN
+        uses: nais/deploy/actions/cdn-upload/v2@master
+        with:
+          team: flex
+          source: ./.next/static
+          destination: /${{ github.event.repository.name }}/_next
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+      - name: Fjern dev-avhengigheter
+        run: npm prune --production
+      - name: docker-build-push
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: flex
+          image_suffix: dev
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+
+  bygg-prod:
+    permissions:
+      packages: read
+      contents: read
+      id-token: write
+    name: Bygg og publiser prod
+    timeout-minutes: 15
+    needs: installer
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+    steps:
+      - name: Gjenopprett workspace
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}
+          key: workspace-${{ github.sha }}
+      - name: Next.js cache (prod)
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-prod-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-prod-${{ hashFiles('**/package-lock.json') }}-
+      - name: Kopier prod-miljøfil
+        run: cp nais/envs/.env.prod .env.production
+      - name: Bygg applikasjon
+        run: npm run build
+        env:
+          NEXT_PUBLIC_VERSION: ${{ github.sha }}
+      - name: Last opp statiske filer til NAV CDN
+        uses: nais/deploy/actions/cdn-upload/v2@master
+        with:
+          team: flex
+          source: ./.next/static
+          destination: /${{ github.event.repository.name }}/_next
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+      - name: Fjern dev-avhengigheter
+        run: npm prune --production
+      - name: docker-build-push
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: flex
+          image_suffix: prod
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+
+  lint:
+    name: lint
+    timeout-minutes: 15
+    needs: installer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gjenopprett workspace
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}
+          key: workspace-${{ github.sha }}
+      - name: Run prettier
+        run: npm run prettier:check
+      - name: Run lint
+        run: npm run lint
+
+  unit-test:
+    name: unit-test
+    timeout-minutes: 15
+    needs: installer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gjenopprett workspace
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}
+          key: workspace-${{ github.sha }}
+      - name: Run tests
+        run: npm run test:ci
+
+  codeql-analyse:
+    if: github.ref_name == 'main' || startsWith(github.ref_name, 'dev-')
+    name: codeql-analyse
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          queries: security-and-quality
+          languages: javascript
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:javascript
+
+  bygg-demo:
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+    name: Bygg, test og publiser docker image
+    runs-on: ubuntu-latest
+    needs: installer
+    env:
+      IMAGE_NAME: ${{ github.repository }}-e2e
+      REGISTRY: ghcr.io
+    outputs:
+      image-gar: ${{ steps.docker-build-push.outputs.image }}
+      image-ghcr: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+    steps:
+      - name: Gjenopprett workspace
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}
+          key: workspace-${{ github.sha }}
+      - name: Next.js cache (demo)
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-demo-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-demo-${{ hashFiles('**/package-lock.json') }}-
+      - name: Kopier demo-miljøfil
+        run: cp nais/envs/.env.demo .env.production
+      - name: Bygg applikasjon
+        run: npm run build
+        env:
+          NEXT_PUBLIC_VERSION: ${{ github.sha }}
+      - name: Fjern dev-avhengigheter
+        run: npm prune --production
+      - name: docker-build-push til GAR
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: flex
+          image_suffix: demo
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+      - name: Logg inn i Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Bygg og push Docker image til ghcr (Playwright)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+  playwright:
+    needs: [installer, bygg-demo]
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v${{ needs.installer.outputs.playwright-version }}-noble
+      options: --user 1001
+    services:
+      app-main:
+        image: ${{ needs.bygg-demo.outputs.image-ghcr }}
+        ports: ['3000:3000']
+        env:
+          NO_DECORATOR: 'true'
+      app-decorator:
+        image: ${{ needs.bygg-demo.outputs.image-ghcr }}
+        ports: ['3001:3000']
+        env:
+          NO_DECORATOR: 'false'
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4, 5, 6]
+        shardTotal: [6]
+    steps:
+      - uses: actions/checkout@v7
+      - run: npm ci
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Playwright
+        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        env:
+          APP_BASEURL: http://app-main:3000
+          APP_DECORATOR_BASEURL: http://app-decorator:3000
+      - name: Last opp Playwright-rapport til GitHub Actions
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: blob-report
+          retention-days: 1
+
+  playwright-rapport:
+    if: ${{ !cancelled() && !startsWith(github.ref_name, 'dependabot/') }}
+    needs: [playwright]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - name: Last ned rapporter
+        uses: actions/download-artifact@v8
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+      - name: Merge til HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+      - name: Last opp til CDN
+        uses: nais/deploy/actions/cdn-upload/v2@master
+        with:
+          team: flex
+          source: playwright-report
+          destination: /${{ github.repository }}/${{ github.run_number }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+      - name: Merge til json rapport
+        run: npx playwright merge-reports --reporter json ./all-blob-reports > playwright-report/report.json
+      - name: Lag GHA summary
+        run: |
+          total_tests=$(jq '.stats.expected + .stats.unexpected' playwright-report/report.json)
+          passed_tests=$(jq '.stats.expected' playwright-report/report.json)
+          failed_tests=$(jq '.stats.unexpected' playwright-report/report.json)
+          failed_test_info=$(jq -r '.suites[].suites[].specs[] | select(.ok == false) | "\(.title) (\(.file), \(.tests[].projectName))"' playwright-report/report.json)
+
+          echo "## Playwright Test Report Summary" >> $GITHUB_STEP_SUMMARY
+          echo "Total tests: $total_tests ✅" >> $GITHUB_STEP_SUMMARY
+          echo "Passed tests: $passed_tests ✅" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$failed_tests" -gt 0 ]; then
+            echo "Failed tests: $failed_tests ❌" >> $GITHUB_STEP_SUMMARY
+            echo "### Failed Tests:" >> $GITHUB_STEP_SUMMARY
+            while IFS= read -r test; do
+              echo "- $test ❌" >> $GITHUB_STEP_SUMMARY
+            done <<< "$failed_test_info"
+          else
+            echo "Failed tests: $failed_tests 🔹" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "Se hele rapporten [her](https://cdn.nav.no/flex/${{ github.repository }}/${{ github.run_number }}/playwright-report/index.html)." >> $GITHUB_STEP_SUMMARY
+
+  deploy-til-dev:
+    if: github.ref_name == 'main' || startsWith(github.ref_name, 'dev-')
+    name: Deploy til dev
+    timeout-minutes: 15
+    needs: [bygg-dev, playwright, unit-test]
+    runs-on: ubuntu-latest
+    concurrency: deploy-${{ inputs.app }}-til-dev
+    steps:
+      - uses: actions/checkout@v7
+      - uses: nais/deploy/actions/deploy@v2
+        name: Deploy til dev-gcp
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: nais/app/naiserator.yaml
+          VAR: image=${{ needs.bygg-dev.outputs.image }},kafkaPool=nav-dev,unleash-environment=development
+          VARS: nais/app/dev.yaml
+
+  deploy-til-prod:
+    if: github.ref_name == 'main'
+    name: Deploy til prod
+    timeout-minutes: 15
+    needs: [bygg-prod, playwright, unit-test]
+    runs-on: ubuntu-latest
+    concurrency: deploy-${{ inputs.app }}-til-prod
+    steps:
+      - uses: actions/checkout@v7
+      - uses: nais/deploy/actions/deploy@v2
+        name: Deploy til prod-gcp
+        env:
+          CLUSTER: prod-gcp
+          RESOURCE: nais/app/naiserator.yaml
+          VAR: image=${{ needs.bygg-prod.outputs.image }},kafkaPool=nav-prod,unleash-environment=production
+          VARS: nais/app/prod.yaml
+
+  deploy-demo-branch-til-dev-gcp:
+    if: startsWith(github.ref_name, 'demo-') || startsWith(github.ref_name, 'dev-')
+    name: Deploy demo branch til dev-gcp
+    timeout-minutes: 15
+    needs: [bygg-demo]
+    runs-on: ubuntu-latest
+    env:
+      DEMO_APPNAME: demo-${{ inputs.app }}-${{ github.ref_name }}
+      DEMO_INGRESS: ${{ inputs.app }}-${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Deploy demo branch til dev-gcp
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: nais/app/demo.yaml
+          IMAGE: ${{ needs.bygg-demo.outputs.image-gar }}
+          VAR: appname=${{ env.DEMO_APPNAME }},replicas=1,branchState=alive,ingress=https://${{ env.DEMO_INGRESS }}.ekstern.dev.nav.no/${{ inputs.base-path }},TTL_HOURS=168h
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_MESSAGE: 'Ny demo versjon av ${{ inputs.app }} ute :rocket: https://${{ env.DEMO_INGRESS }}.ekstern.dev.nav.no/${{ inputs.base-path }}'
+          SLACK_TITLE: ${{ github.ref_name }}
+          SLACK_USERNAME: Demo deploy
+          SLACK_ICON: ':lab_coat:'
+          SLACK_WEBHOOK: ${{ secrets.LABS_DEPLOY_WEBHOOK }}
+
+  deploy-demo-til-dev-gcp:
+    if: github.ref_name == 'main'
+    name: Deploy demo til dev-gcp
+    timeout-minutes: 15
+    needs: [bygg-demo]
+    concurrency: deploy-demo-til-dev-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Deploy til dev-gcp
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: nais/app/demo.yaml
+          IMAGE: ${{ needs.bygg-demo.outputs.image-gar }}
+          VAR: appname=demo-${{ inputs.app }},replicas=1,branchState=alive,ingress=https://demo.ekstern.dev.nav.no/${{ inputs.base-path }}
+
+
+


### PR DESCRIPTION
Er noen repeterende deler etc som kan splittes ut og ryddes i etterhvert. Men det er ikke så viktig i førsteomgang tenker jeg. Burde også pinne med SHA, fjerne master etc.

Jukser også litt med navnene for bygging av demo til å fortsatt bruke Bygg, test og publiser docker image, slik at eksisterende PR sjekker på github ikke trengs å fikses på enda